### PR TITLE
fix(attribute): add quotes around href attribute

### DIFF
--- a/src/converter.py
+++ b/src/converter.py
@@ -17,7 +17,7 @@ def link_md_to_html(md_link):
     phrase_split = md_link.split("]")
     text_link = phrase_split[0][1:]
     url_link = phrase_split[1][1:-1]
-    link_html = "<a href=" + url_link + ">" + text_link + "</a>"
+    link_html = "<a href='" + url_link + "'>" + text_link + "</a>"
     return link_html
 
 """


### PR DESCRIPTION
Should resolve #19. Moving forward, attributes should have single quotes around them. 

https://github.com/AumitLeon/markdown_html_converter/blob/ce439ac92a2159253f7c970f96dcd36a7b3c03ec/src/converter.py#L20