### PR TITLE
chore(docs): use rtd theme for docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+extra_css: [extra.css]
+site_name: md-to-html
+theme: readthedocs
+theme:
+    name: readthedocs
+    highlightjs: true
+    hljs_languages:
+        - python


### PR DESCRIPTION
Update theme to use RTD default theme for docs site.