### PR TITLE
fix: format setup.py version using black on automatic version bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
           name: run black (code format check)
           command: |
             . venv/bin/activate
+            black setup.py
             black --check setup.py src/
       - run:
           name: run tests and format check


### PR DESCRIPTION
Resolve #48. The build workflow will always be called, so we should just automatically format the setup.py file to use double quotes after python-semantic-release automatically bumps the version using single quotes. Otherwise, a fork of the python-semantic-release package that uses single quotes is the alternative fix. 