### PR TITLE
Early exit for forks and fix gitdb issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,23 @@
 version: 2
+commands:
+  early_return_for_forked_pull_requests:
+    description: >-
+      If this build is from a fork, stop executing the current job and return success.
+      This is useful to avoid steps that will fail due to missing credentials.
+    steps:
+      - run:
+          name: Early return if this build is from a forked PR
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
 jobs:
   build:
     docker:
       - image: circleci/python:3.7
     steps:
       - checkout
-
       - restore_cache:
           key: v1-dependency-cache-{{ checksum "setup.py" }}
 
@@ -35,6 +47,7 @@ jobs:
     docker:
       - image: circleci/python:3.7
     steps:
+      - early_return_for_forked_pull_requests
       - checkout
 
       - restore_cache:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ python-semantic-release-pypi
 pytest
 pre-commit
 black
+gitdb>=3.1


### PR DESCRIPTION
Exit CI workflows for forked PRs before executing a step that requires env vars (would otherwise fail when it got to those steps). See: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/

Also fix this gitdb issue: https://github.com/gitpython-developers/GitPython/issues/983