### PR TITLE
fix: Require python version >= 3.5 for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ The purpose of this project is to create a simple to use python module that can 
 
 This project is preconfigured with [CircleCi](https://circleci.com/) for continuous integration and delivery; releases are automated via `semantic-release.`
 
+## Requirements
+This module requires python version >= 3.5.
 ## Installation
+
 To install this module:
 ```
 pip install md-to-html

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-python-semantic-release-pypi
-pytest
-pre-commit
-black
+python-semantic-release-pypi==3.11.2
+pytest==6.2.0
+pre-commit==2.9.3
+black==20.8b1
 gitpython>=3.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-python-semantic-release-pypi==3.11.2
+python-semantic-release==7.7.0
 pytest==6.2.0
 pre-commit==2.9.3
 black==20.8b1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest==6.2.0
 pre-commit==2.9.3
 black==20.8b1
 gitpython>=3.1
+pyparsing==2.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mistune
-beautifulsoup4
+mistune==0.8.4
+beautifulsoup4==4.9.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 # Should match git tag
-VERSION = '0.7.0'
+VERSION = "0.7.0"
 
 
 def readme():
@@ -31,4 +31,5 @@ setup(
     extras_require={"dev": DEVELOPMENT_MODULES},
     entry_points={"console_scripts": ["md-to-html=src.converter:main"],},
     include_package_data=True,
+    python_requires=">=3.5",
 )


### PR DESCRIPTION
Resolves #60. 

Opening the input and output files uses python's built-in `open` function.
The `open` function invocation we use includes the `encoding` keyword, which was added in python 3.