### PR TITLE
fix: Generate a new release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           name: init .pypirc
           command: |
             echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username = aumitleon" >> ~/.pypirc
+            echo -e "username = __token__" >> ~/.pypirc
             echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
       - run:
           name: create packages


### PR DESCRIPTION
`python-semantic-release==7.7.0` requires that we use a PYPI token instead of username and password.
https://python-semantic-release.readthedocs.io/en/latest/envvars.html#env-pypi-token